### PR TITLE
Set Scrobbler to be enabled by default

### DIFF
--- a/mopidy.conf.tmpl
+++ b/mopidy.conf.tmpl
@@ -12,5 +12,6 @@ username = ___SPOTIFY_USERNAME___
 password = ___SPOTIFY_PASSWORD___
 
 [scrobbler]
+enabled = true
 username = ___SCROBBLER_USERNAME___
 password = ___SCROBBLER_PASSWORD___


### PR DESCRIPTION
We haven't been scrobbling on **last.fm** since March because we forgot to enable it (while entering correctly the username and password). Added the missing line in the config template so we don't forget again.

Now the entire world knows that @abigailricarte plays Beyonce all day, that @karlsluis is in charge of LCD Soundsystem (thank you), and that I annoy everyone with Thee Oh Sees 👅

http://www.last.fm/user/tunebotnbs to enjoy the show

<img width="676" alt="screen shot 2015-07-10 at 6 55 56 pm" src="https://cloud.githubusercontent.com/assets/3630005/8630558/5b4e3362-2735-11e5-8750-a24c340c2dad.png">

